### PR TITLE
HOTFIX for pi-hole: the domains are not correctly parsed

### DIFF
--- a/KADhosts.txt
+++ b/KADhosts.txt
@@ -31238,7 +31238,7 @@
 0.0.0.0 noworldhunger.com
 0.0.0.0 nows.lidoks.xyz
 0.0.0.0 nowyaletaniec.website
-0.0.0.0 nowyouknocom
+0.0.0.0 nowyouknow.com
 0.0.0.0 nox.polex.live
 0.0.0.0 noyatransfer.com
 0.0.0.0 nozaruyj.live
@@ -33187,7 +33187,7 @@
 0.0.0.0 pl-bezpieczna-oferta119890.pl
 0.0.0.0 pl-bezpieczna-platnosc.pl
 0.0.0.0 pl-binance.com
-0.0.0.0 pl-com
+0.0.0.0 pl-com.com
 0.0.0.0 pl-fakty.digitalmediacouncil.com
 0.0.0.0 pl-help.top
 0.0.0.0 pl-in-post.sbs


### PR DESCRIPTION
Hi !

You can find here a solution to avoid this error when you update the gravity for Pi-Hole :

![image](https://github.com/FiltersHeroes/KADhosts/assets/44984461/d3cfe6e7-26fd-44c1-9356-2ccc465c54fe)

Thanks in advance,
Xen0r.